### PR TITLE
Suggested changes for trig support/prefix highlighting

### DIFF
--- a/grammars/trig.cson
+++ b/grammars/trig.cson
@@ -1,0 +1,10 @@
+'name': 'Trig'
+'scopeName': 'source.trig'
+'fileTypes': [
+  'trig'
+]
+'patterns': [
+  {
+    'include': 'source.turtle'
+  }
+]

--- a/grammars/turtle.cson
+++ b/grammars/turtle.cson
@@ -20,10 +20,11 @@
     'match': '((?:\\w(?:(?:\\w|-|[\\xB7\\x{0300}-\\x{036F}\\x{203F}-\\x{2040}]|\\.)*(?:\\w|-|[\\xB7\\x{0300}-\\x{036F}\\x{203F}-\\x{2040}]))?)?:)([^\\s|/^*?+{}()]*)'
     'captures':
       '1':
-        'name': 'entity.name.tag.namespace.turtle'
+        'name': 'entity.name.class.namespace.turtle'
       '2':
         'name': 'entity.name.tag.prefixed-uri.turtle'
   }
+
   {
     'comment': 'The special triple predicate a'
     'name': 'keyword.operator.turtle'

--- a/settings/language-rdf.cson
+++ b/settings/language-rdf.cson
@@ -4,3 +4,6 @@
 '.source.ntriples':
   'editor':
     'commentStart': '# '
+'.source.trig':
+  'editor':
+    'commentStart': '# '

--- a/snippets/language-rdf.cson
+++ b/snippets/language-rdf.cson
@@ -1,11 +1,11 @@
-'.source.turtle':
+'.source.turtle, .source.trig':
   'Turtle Skeleton':
     'prefix': 'skel'
     'body': '@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.\n@prefix $1: <http://$2>.\n\n$0'
   'Prefix':
     'prefix': 'prefix'
     'body': '@prefix ${1:rdf}: <${2:http://www.w3.org/1999/02/22-rdf-syntax-ns#}>'
-'.source.ntriples':
+'.source.ntriples, .source.trig':
   'RDF':
     'prefix': 'rdf'
     'body': '<http://www.w3.org/1999/02/22-rdf-syntax-ns#$1> $0'
@@ -21,3 +21,6 @@
   'A (rdf-type)':
     'prefix': 'a'
     'body': '<http://www.w3.org/1999/02/22-rdf-syntax-ns#type> $0'
+  'XSD':
+    'prefix': 'xsd'
+    'body': '<http://www.w3.org/2001/XMLSchema#> $0'


### PR DESCRIPTION
-Added the trig grammar file(with no unique rules)
-Added the necessary selectors to the snippets to get those in trig
-Suggesting that a .class class is added to the prefix rule to get a separate color for the prefix. Theme's by default know how to style entity.class differently.

https://www.dropbox.com/s/mtdyve1wrd925i6/Screenshot%202016-12-02%2017.18.31.png?dl=0